### PR TITLE
Make the profile schedulers daemon threads

### DIFF
--- a/src/client/java/com/tiers/PlayerProfileQueue.java
+++ b/src/client/java/com/tiers/PlayerProfileQueue.java
@@ -10,7 +10,11 @@ import java.util.concurrent.TimeUnit;
 
 public class PlayerProfileQueue {
     private static final ConcurrentLinkedDeque<PlayerProfile> queue = new ConcurrentLinkedDeque<>();
-    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "tiers-profile-queue");
+        t.setDaemon(true);
+        return t;
+    });
 
     private static PlayerProfile currentProfile = null;
 

--- a/src/client/java/com/tiers/profile/types/SuperProfile.java
+++ b/src/client/java/com/tiers/profile/types/SuperProfile.java
@@ -21,7 +21,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.tiers.TiersClient.*;
 
 public class SuperProfile {
-    private static final ScheduledExecutorService updateAndRecoverFailedRequestsScheduler = Executors.newSingleThreadScheduledExecutor();
+    private static final ScheduledExecutorService updateAndRecoverFailedRequestsScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "tiers-superprofile-scheduler");
+        t.setDaemon(true);
+        return t;
+    });
     public static final CopyOnWriteArrayList<SuperProfile> failedSuperProfiles = new CopyOnWriteArrayList<>();
 //    public static final AtomicInteger MCTiersRequests = new AtomicInteger(0);
     public static final AtomicInteger PvPTiersRequests = new AtomicInteger(0);


### PR DESCRIPTION
`PlayerProfileQueue` and `SuperProfile` both spin up a `ScheduledExecutorService` with the default thread factory, so those threads aren't daemon threads. They run forever, which keeps the JVM alive after you close the game.

On 26.2 that's a real problem. Mojang added a shutdown watchdog that force kills the process with exit code -8 if it hasn't exited about 15s after the game closes. The two scheduler threads are exactly what's left hanging, so every quit ends in a -8 crash.

Fix is just giving both schedulers a daemon thread factory. No behaviour change otherwise.
