### PR TITLE
perf: improvements to profile lookups

### DIFF
--- a/src/client/java/com/tiers/PlayerProfileQueue.java
+++ b/src/client/java/com/tiers/PlayerProfileQueue.java
@@ -74,9 +74,22 @@ public class PlayerProfileQueue {
         queue.remove(playerProfile);
     }
 
+    private static final int MAX_RECOVERY_ATTEMPTS = 6;
+
     private static void recoverFailedRequests() {
+        long now = System.currentTimeMillis();
         for (PlayerProfile playerProfile : PlayerProfile.failedPlayerProfiles) {
+            if (now < playerProfile.nextRetryAt)
+                continue;
+
             PlayerProfile.failedPlayerProfiles.remove(playerProfile);
+
+            // Cap retries with exponential backoff so outages don't generate unbounded API requests; /tiers -clear allows a manual retry.
+            if (playerProfile.recoveryAttempts >= MAX_RECOVERY_ATTEMPTS)
+                continue;
+
+            playerProfile.recoveryAttempts++;
+            playerProfile.nextRetryAt = now + TimeUnit.MINUTES.toMillis(1L << Math.min(playerProfile.recoveryAttempts, 4));
             playerProfile.prepareToRebuild();
             putLastInQueue(playerProfile);
         }

--- a/src/client/java/com/tiers/TiersClient.java
+++ b/src/client/java/com/tiers/TiersClient.java
@@ -139,7 +139,7 @@ public class TiersClient implements ClientModInitializer {
         PlayerProfile newProfile = new PlayerProfile(playerName, true);
 
         // On online-mode servers the GameProfile already carries the real Mojang UUID, so the username->UUID API round-trip is unnecessary.
-        if (knownUuid != null && PlayerProfile.isRealUuid(knownUuid) && newProfile.status == Status.SEARCHING)
+        if (PlayerProfile.isRealUuid(knownUuid) && newProfile.status == Status.SEARCHING)
             newProfile.completeWithKnownUuid(knownUuid);
         else if (priority)
             PlayerProfileQueue.putFirstInQueue(newProfile);

--- a/src/client/java/com/tiers/TiersClient.java
+++ b/src/client/java/com/tiers/TiersClient.java
@@ -121,6 +121,10 @@ public class TiersClient implements ClientModInitializer {
     }
 
     public static PlayerProfile addGetPlayer(String playerName, boolean priority) {
+        return addGetPlayer(playerName, priority, null);
+    }
+
+    public static PlayerProfile addGetPlayer(String playerName, boolean priority, UUID knownUuid) {
         PlayerProfile gotFromReady = readyPlayerProfiles.get(playerName);
         if (gotFromReady != null)
             return gotFromReady;
@@ -134,7 +138,10 @@ public class TiersClient implements ClientModInitializer {
         }
         PlayerProfile newProfile = new PlayerProfile(playerName, true);
 
-        if (priority)
+        // On online-mode servers the GameProfile already carries the real Mojang UUID, so the username->UUID API round-trip is unnecessary.
+        if (knownUuid != null && PlayerProfile.isRealUuid(knownUuid) && newProfile.status == Status.SEARCHING)
+            newProfile.completeWithKnownUuid(knownUuid);
+        else if (priority)
             PlayerProfileQueue.putFirstInQueue(newProfile);
         else
             PlayerProfileQueue.enqueue(newProfile);

--- a/src/client/java/com/tiers/mixin/client/AddRenderedPlayersClientMixin.java
+++ b/src/client/java/com/tiers/mixin/client/AddRenderedPlayersClientMixin.java
@@ -14,6 +14,6 @@ public abstract class AddRenderedPlayersClientMixin {
     @Inject(at = @At(value = "TAIL"), method = "<init>")
     private void onConstruct(final Level level, final GameProfile gameProfile, CallbackInfo ci) {
         if (TiersClient.toggleMod)
-            TiersClient.addGetPlayer(gameProfile.name(), false);
+            TiersClient.addGetPlayer(gameProfile.name(), false, gameProfile.id());
     }
 }

--- a/src/client/java/com/tiers/mixin/client/ModifyNametagsClientMixin.java
+++ b/src/client/java/com/tiers/mixin/client/ModifyNametagsClientMixin.java
@@ -1,6 +1,7 @@
 package com.tiers.mixin.client;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.mojang.authlib.GameProfile;
 import com.tiers.TiersClient;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
@@ -13,6 +14,9 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class ModifyNametagsClientMixin {
     @Shadow
     public abstract String getScoreboardName();
+
+    @Shadow
+    public abstract GameProfile getGameProfile();
 
     @Unique
     private int tiers_cacheVersion;
@@ -33,6 +37,6 @@ public abstract class ModifyNametagsClientMixin {
         tiers_cacheVersion = TiersClient.cacheVersion;
         tiers_lastOriginal = original;
 
-        return tiers_cached = TiersClient.addGetPlayer(getScoreboardName(), false).getFullName(original);
+        return tiers_cached = TiersClient.addGetPlayer(getScoreboardName(), false, getGameProfile().id()).getFullName(original);
     }
 }

--- a/src/client/java/com/tiers/mixin/client/ModifyTabClientMixin.java
+++ b/src/client/java/com/tiers/mixin/client/ModifyTabClientMixin.java
@@ -29,7 +29,7 @@ public abstract class ModifyTabClientMixin {
     @Inject(at = @At(value = "TAIL"), method = "<init>")
     private void onConstruct(GameProfile profile, boolean enforcesSecureChat, CallbackInfo ci) {
         if (TiersClient.toggleMod)
-            TiersClient.addGetPlayer(profile.name(), false);
+            TiersClient.addGetPlayer(profile.name(), false, profile.id());
     }
 
     @ModifyReturnValue(at = @At("RETURN"), method = "getTabListDisplayName")
@@ -42,6 +42,6 @@ public abstract class ModifyTabClientMixin {
         tiers_cacheVersion = TiersClient.cacheVersion;
         tiers_lastOriginal = original;
 
-        return tiers_cached = TiersClient.addGetPlayer(getProfile().name(), false).deepReplace(original);
+        return tiers_cached = TiersClient.addGetPlayer(getProfile().name(), false, getProfile().id()).deepReplace(original);
     }
 }

--- a/src/client/java/com/tiers/profile/PlayerProfile.java
+++ b/src/client/java/com/tiers/profile/PlayerProfile.java
@@ -63,6 +63,8 @@ public class PlayerProfile {
     private Component deepReplaceName;
 
     private int numberOfRequests;
+    public int recoveryAttempts;
+    public long nextRetryAt;
     private final boolean regular;
 
     private static final String UUID_API_1 = "https://playerdb.co/api/player/minecraft/";
@@ -274,6 +276,10 @@ public class PlayerProfile {
             uuid = jsonObject.get("id").getAsString();
         }
 
+        finishResolution();
+    }
+
+    private void finishResolution() {
         if (uuid.isEmpty()) {
             status = Status.NOT_EXISTING;
             return;
@@ -290,6 +296,19 @@ public class PlayerProfile {
         updateTierlistProfiles(0);
         status = Status.READY;
         readyPlayerProfiles.put(targetName, this);
+    }
+
+    public void completeWithKnownUuid(java.util.UUID knownUuid) {
+        if (status != Status.SEARCHING)
+            return;
+
+        uuid = knownUuid.toString().replace("-", "");
+        finishResolution();
+    }
+
+    public static boolean isRealUuid(java.util.UUID id) {
+        // Offline-mode servers derive version-3 UUIDs from the name; only version-4 UUIDs are real Mojang accounts safe to skip the lookup for.
+        return id != null && id.version() == 4;
     }
 
     private void failedRequest() {


### PR DESCRIPTION
This PR adds a bypass for online mode UUIDs to immediately resolve instead of reaching out to an API. They're from a trusted source so there's no need for a double check. It also adds a cap and exponential backoff to retries, that way clients aren't infinitely retrying a bad request. 